### PR TITLE
Dependencies: clojure -> org.clojure/clojure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject imgcompare "0.0.1-SNAPSHOT"
   :description "Image comparison"
-  :dependencies [[clojure "1.3.0"]]
+  :dependencies [[org.clojure/clojure "1.3.0"]]
   :dev-dependencies [[swank-clojure "1.3.2"]]
   :main imgcompare.core)


### PR DESCRIPTION
I want to use imgcompare via jitpack.io, and to do that it should have valid dependencies:
https://jitpack.io/com/github/zakwilson/imgcompare/58c72991c7/build.log

```
Could not find artifact clojure:clojure:jar:1.3.0 in central (https://repo1.maven.org/maven2/)
Could not find artifact clojure:clojure:jar:1.3.0 in clojars (https://clojars.org/repo/)
```